### PR TITLE
Run build for downstream projects as well.

### DIFF
--- a/.github/workflows/build-and-deploy-snapshot.yml
+++ b/.github/workflows/build-and-deploy-snapshot.yml
@@ -2,7 +2,6 @@ name: build and deploy snapshots
 on: [push]
 jobs:
   build:
-    if: github.repository == 'QW-Group/mvdparser'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,24 +47,29 @@ jobs:
       - name: Create checksum
         run: |
              md5sum build/${{ matrix.target }}/mvdparser${{ matrix.ext }} > build/${{ matrix.target }}/mvdparser.md5
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: ${{ matrix.target }}
-#          path: |
-#                build/${{ matrix.target }}/mvdparser${{ matrix.ext }}
-#          if-no-files-found: ignore
+      - name: Upload artifacts
+        if: github.repository != 'QW-Group/mvdparser'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}
+          path: |
+                build/${{ matrix.target }}/mvdparser${{ matrix.ext }}
+                build/${{ matrix.target }}/mvdparser.md5
+          if-no-files-found: ignore
       - name: Setup SSH
+        if: github.repository == 'QW-Group/mvdparser'
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: Set date
+        if: github.repository == 'QW-Group/mvdparser'
         run: |
           sudo timedatectl set-timezone Europe/Amsterdam
           echo "DATE=$(date "+%Y%m%d-%H%M%S")" >> $GITHUB_ENV
       - name: Deploy
+        if: github.repository == 'QW-Group/mvdparser'
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |


### PR DESCRIPTION
Uploads binaries as build artifacts rather than to the snapshots server.