### PR TITLE
Makefile changes for cygwin mingw win32-64 builds and a zip release with readme file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq "$(OS)" "linux"
 	CC=$(CC_LIN)
 else	## windows
 	SOURCES = src/frag_parser.c src/logger.c src/main.c src/mvd_parser.c src/net_msg.c src/netmsg_parser.c src/qw_protocol.c src/shared.c src/strptime.c src/sys_win.c
-	CC=$(CC_WIN) -mno-cygwin -L/lib/w32api
+	CC=$(CC_WIN) -L/lib/w32api
 	CCFLAGS+=-Wl,--allow-multiple-definition -Wl,--enable-auto-import
 	EXTRA_LIBS=-lwinmm
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ None at the moment.
 
 ## Building binaries
 
+### Build from source with mingw32-make in cygwin
+
+Navigate to Makefile in cygwin terminal and use mingw32-make to make.
+
 ### Build from source with CMake
 
 Assuming you have installed essential build tools and ``CMake``

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ None at the moment.
 
 ## Building binaries
 
-### Build from source with mingw32-make in cygwin
-
-Navigate to Makefile in cygwin terminal and use mingw32-make to make.
-
 ### Build from source with CMake
 
 Assuming you have installed essential build tools and ``CMake``
@@ -66,6 +62,10 @@ force CMake generator to be unix makefiles
 
 build MVDPARSER for ``linux-amd64`` version, you can provide
 any platform combinations.
+
+### Build from source with mingw32-make in cygwin
+
+Navigate to Makefile in cygwin terminal and use mingw32-make to make.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ any platform combinations.
 
 ### Build from source with mingw32-make in cygwin
 
-Navigate to Makefile in cygwin terminal and use mingw32-make to make.
+Install (for cygwin), 
+mingw64-x86_64-gcc-core
+mingw64-i686-gcc-core
+cygwin-mingw
+
+Navigate to Makefile in cygwin.
+Use mingw32-make to make.
 
 ## Versioning
 


### PR DESCRIPTION
The current cygwin gcc compiles only for cygwin itself.

-mno-cygwin is an obsolete flag from gcc 3.x time that allowed the cygwin compiler to compile mingw (not cygwin) programs.

The switch was removed long time ago and true cross compilers

mingw64-x86_64-gcc-core
mingw64-i686-gcc-core
cygwin-mingw

were made available