### PR TITLE
memmove() instead of strcpy()

### DIFF
--- a/src/netmsg_parser.c
+++ b/src/netmsg_parser.c
@@ -102,7 +102,7 @@ void Info_RemoveKey(char *s, char *key)
 
 		if (!strcmp(key, pkey))
 		{
-			strcpy(start, s);	// Remove this part.
+			memmove(start, s, strlen(s)+1);	// Remove this part.
 			return;
 		}
 


### PR DESCRIPTION
Here we strcpy() into overlapping memory which is undefined behavior. Use memmove() instead which allows overlapping areas.

Fixes #35
