### PR TITLE
Add protocol extensions.

### DIFF
--- a/src/netmsg_parser.c
+++ b/src/netmsg_parser.c
@@ -546,6 +546,9 @@ static void NetMsg_Parser_ParseEntityDelta(unsigned int bits, unsigned int moreb
 {
 	if (bits & U_MODEL)
 		MSG_ReadByte();
+	else if (morebits & U_FTE_MODELDBL)
+		MSG_ReadShort();
+
 	if (bits & U_FRAME)
 		MSG_ReadByte();
 	if (bits & U_COLORMAP)
@@ -1288,10 +1291,10 @@ static void NetMsg_Parser_Parse_svc_chokecount(void)
 	MSG_ReadByte();
 }
 
-static void NetMsg_Parser_Parse_svc_modellist(void)
+static void NetMsg_Parser_Parse_svc_modellist(qbool extended)
 {
 	char *str;
-	int model_count = MSG_ReadByte();
+	int model_count = extended ? MSG_ReadShort() : MSG_ReadByte();
 
 	while (true)
 	{
@@ -1592,7 +1595,12 @@ qbool NetMsg_Parser_StartParse(mvd_info_t *mvd)
 			}
 			case svc_modellist :
 			{
-				NetMsg_Parser_Parse_svc_modellist();
+				NetMsg_Parser_Parse_svc_modellist(false);
+				break;
+			}
+			case svc_fte_modellistshort :
+			{
+				NetMsg_Parser_Parse_svc_modellist(true);
 				break;
 			}
 			case svc_soundlist :

--- a/src/netmsg_parser.c
+++ b/src/netmsg_parser.c
@@ -962,6 +962,13 @@ static void NetMsg_Parser_Parse_svc_spawnstatic(void)
 	}
 }
 
+static void NetMsg_Parser_Parse_svc_fte_spawnstatic2(void)
+{
+	unsigned int entnum, bits, morebits;
+	NetMsg_Parser_ParseEntityNum(&entnum, &bits, &morebits);
+	NetMsg_Parser_ParseEntityDelta(bits, morebits);
+}
+
 static void NetMsg_Parser_Parse_svc_spawnbaseline(void)
 {
 	int i;
@@ -977,6 +984,13 @@ static void NetMsg_Parser_Parse_svc_spawnbaseline(void)
 		MSG_ReadCoord();	// Origin.
 		MSG_ReadAngle();	// Angles.
 	}
+}
+
+static void NetMsg_Parser_Parse_svc_fte_spawnbaseline2(void)
+{
+	unsigned int entnum, bits, morebits;
+	NetMsg_Parser_ParseEntityNum(&entnum, &bits, &morebits);
+	NetMsg_Parser_ParseEntityDelta(bits, morebits);
 }
 
 static void NetMsg_Parser_Parse_svc_temp_entity(void)
@@ -1596,6 +1610,11 @@ qbool NetMsg_Parser_StartParse(mvd_info_t *mvd)
 				NetMsg_Parser_Parse_svc_spawnbaseline();
 				break;
 			}
+			case svc_fte_spawnbaseline2 :
+			{
+				NetMsg_Parser_Parse_svc_fte_spawnbaseline2();
+				break;
+			}
 			case svc_updatefrags :
 			{
 				NetMsg_Parser_Parse_svc_updatefrags(mvd);
@@ -1709,6 +1728,11 @@ qbool NetMsg_Parser_StartParse(mvd_info_t *mvd)
 			case svc_spawnstatic :
 			{
 				NetMsg_Parser_Parse_svc_spawnstatic();
+				break;
+			}
+			case svc_fte_spawnstatic2 :
+			{
+				NetMsg_Parser_Parse_svc_fte_spawnstatic2();
 				break;
 			}
 			case svc_foundsecret :

--- a/src/netmsg_parser.c
+++ b/src/netmsg_parser.c
@@ -566,6 +566,9 @@ static void NetMsg_Parser_ParseEntityDelta(unsigned int bits, unsigned int moreb
 		MSG_ReadAngle();
 	if (bits & U_ANGLE3)
 		MSG_ReadAngle();
+
+	if (morebits & U_FTE_TRANS)
+		MSG_ReadByte();
 }
 
 // ========================================================================================

--- a/src/netmsg_parser.c
+++ b/src/netmsg_parser.c
@@ -569,6 +569,13 @@ static void NetMsg_Parser_ParseEntityDelta(unsigned int bits, unsigned int moreb
 
 	if (morebits & U_FTE_TRANS)
 		MSG_ReadByte();
+
+	if (morebits & U_FTE_COLOURMOD)
+	{
+		MSG_ReadByte(); // r
+		MSG_ReadByte(); // g
+		MSG_ReadByte(); // b
+	}
 }
 
 // ========================================================================================

--- a/src/qw_protocol.c
+++ b/src/qw_protocol.c
@@ -78,7 +78,7 @@ char *svc_strings[] =
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",
-	"NEW PROTOCOL",
+	"svc_fte_modellistshort",
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",

--- a/src/qw_protocol.c
+++ b/src/qw_protocol.c
@@ -33,7 +33,7 @@ char *svc_strings[] =
 	"svc_damage",			// [byte] impact [byte] blood [vec3] from
 
 	"svc_spawnstatic",
-	"OBSOLETE svc_spawnbinary",
+	"svc_fte_spawnstatic2",
 	"svc_spawnbaseline",
 
 	"svc_temp_entity",		// <variable>
@@ -84,7 +84,7 @@ char *svc_strings[] =
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",
 	"NEW PROTOCOL",
-	"NEW PROTOCOL"
+	"svc_fte_spawnbaseline2"
 };
 
 

--- a/src/qw_protocol.h
+++ b/src/qw_protocol.h
@@ -89,7 +89,7 @@ extern char *print_strings[];		// Contains descriptions of the print levels.
 #define	svc_damage				19
 	
 #define	svc_spawnstatic			20
-//	svc_spawnbinary				21
+#define svc_fte_spawnstatic2	21
 #define	svc_spawnbaseline		22
 	
 #define	svc_temp_entity			23	// variable
@@ -138,6 +138,7 @@ extern char *print_strings[];		// Contains descriptions of the print levels.
 #define svc_serverinfo			52		// serverinfo
 #define svc_updatepl			53		// [byte] [byte]
 #define svc_nails2				54		
+#define svc_fte_spawnbaseline2	66
 #define svc_qizmovoice			83
 
 //==============================================

--- a/src/qw_protocol.h
+++ b/src/qw_protocol.h
@@ -138,6 +138,7 @@ extern char *print_strings[];		// Contains descriptions of the print levels.
 #define svc_serverinfo			52		// serverinfo
 #define svc_updatepl			53		// [byte] [byte]
 #define svc_nails2				54		
+#define svc_fte_modellistshort  60
 #define svc_fte_spawnbaseline2	66
 #define svc_qizmovoice			83
 

--- a/src/qw_protocol.h
+++ b/src/qw_protocol.h
@@ -221,14 +221,24 @@ extern char *print_strings[];		// Contains descriptions of the print levels.
 #define	U_MOREBITS	(1 << 15)
 
 // if MOREBITS is set, these additional flags are read in next
-#define	U_ANGLE1	(1 << 0)
-#define	U_ANGLE3	(1 << 1)
-#define	U_MODEL		(1 << 2)
-#define	U_COLORMAP	(1 << 3)
-#define	U_SKIN		(1 << 4)
-#define	U_EFFECTS	(1 << 5)
-#define	U_SOLID		(1 << 6)		// the entity should be solid for prediction
+#define	U_ANGLE1		(1 << 0)
+#define	U_ANGLE3		(1 << 1)
+#define	U_MODEL			(1 << 2)
+#define	U_COLORMAP		(1 << 3)
+#define	U_SKIN			(1 << 4)
+#define	U_EFFECTS		(1 << 5)
+#define	U_SOLID			(1 << 6)		// the entity should be solid for prediction
+#define	U_FTE_EVENMORE	(1 << 7)
 
+// if EVENMORE is set, these additional flags are read in next
+#define	U_FTE_TRANS			(1 << 1)
+#define	U_FTE_MODELDBL		(1 << 3)
+#define	U_FTE_ENTITYDBL		(1 << 5)
+#define	U_FTE_ENTITYDBL2	(1 << 6)
+#define	U_FTE_YETMORE		(1 << 7)
+
+// if YETMORE is set, these additional flags are read in next
+#define	U_FTE_COLOURMOD	(1 << 10)
 //==============================================
 
 // a sound with no channel is a local only sound

--- a/src/shared.c
+++ b/src/shared.c
@@ -156,6 +156,7 @@ size_t strlcpy(char *dst, const char *src, size_t siz)
 }
 #endif // LINUX & WIN32
 
+#if !defined(__APPLE__)
 size_t strlcat(char *dst, const char *src, size_t siz)
 {
 	register char *d = dst;
@@ -185,6 +186,7 @@ size_t strlcat(char *dst, const char *src, size_t siz)
 
 	return(dlen + (s - src));       /* count does not include NUL */
 }
+#endif
 
 // Implemented in later versions of Visual Studio (https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010)
 #if defined(_MSC_VER) && _MSC_VER < 1900

--- a/src/sys_linux.c
+++ b/src/sys_linux.c
@@ -17,7 +17,7 @@
 #include <sys/wait.h>
 #include <sys/mman.h>
 #include <semaphore.h>
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <linux/rtc.h>
 #endif
 #include <sys/ioctl.h>


### PR DESCRIPTION
Support for protocol extensions used in the gameplay protocol for many many years by now, and written by next version of ezQuake & mvdsv.

* PEXT_SPAWNSTATIC2 - Delta spawns for extended attributes
  * svc_fte_spawnstatic2
  * svc_fte_spawnbaseline2
* PEXT_MODELDBL - Up to uint16 model indices
  * svc_fte_modellistshort
* PEXT_TRANS - 1 byte alpha field on entities
* PEXT_COLOURMOD - 3 byte colourmod on entities

PEXT_ENTITYDBL and PEXT_ENTITYDBL2 are also part of the updated protocol, but aren't relevant to mvdparser as entnum is not stored from deltas.